### PR TITLE
CLA-16 - support partial claim retries when there were donation-specific errors

### DIFF
--- a/src/Claimer.php
+++ b/src/Claimer.php
@@ -15,13 +15,16 @@ use Psr\Log\LoggerInterface;
 
 class Claimer
 {
+    /** @var array Assoc on donation ID. Populated on errors so remaining donations can be accessed for retries. */
+    private array $remainingValidDonations = [];
+
     public function __construct(private GiftAid $giftAid, private LoggerInterface $logger)
     {
     }
 
     /**
-     * @param Donation[] $donations
-     * @return bool True if the submission succeeded.
+     * @param Donation[] $donations         Associactive, keyed on donation ID
+     * @return bool                         True if the submission succeeded.
      * @throws DonationDataErrorsException  if at least one donation-specific error was returned
      * @throws HMRCRejectionException       if there is otherwise a specific XML format error from HMRC
      * @throws UnexpectedResponseException  if there was no successful correlation ID but neither of the above error
@@ -44,6 +47,7 @@ class Claimer
                     $donation->org_name,
                     $donation->org_hmrc_ref,
                 ));
+                $orgHMRCRefsAdded[] = $donation->org_hmrc_ref;
             }
 
             if ($claimToDate === null || new \DateTime($donation->donation_date) > $claimToDate) {
@@ -62,6 +66,9 @@ class Claimer
             return true;
         }
 
+        // Copy (unmodified) assoc array with a new name to clarify its use in the rest of the method.
+        $this->remainingValidDonations = $donations;
+
         if (empty($claimOutcome['errors'])) {
             $this->logger->error('Neither correlation ID nor errors. Is the endpoint valid?');
 
@@ -77,9 +84,11 @@ class Claimer
         $failedDonationErrors = [];
         // Make a copy so we can remove donation-particular errors just from this var.
         $nonDonationMappedErrors = $claimOutcome['errors'];
+
         if (!empty($claimOutcome['errors']['business'])) {
             foreach ($claimOutcome['errors']['business'] as $key => $error) {
                 if (!empty($error['donation_id'])) {
+                    unset($this->remainingValidDonations[$error['donation_id']]);
                     $failedDonationErrors[$error['donation_id']] = $error;
                     $this->logger->error(sprintf(
                         'Donation ID %s error at %s: %s',
@@ -110,5 +119,13 @@ class Claimer
         $exception->setRawHMRCErrors($claimOutcome['errors']);
 
         throw $exception;
+    }
+
+    /**
+     * @return Donation[]   Associative, keyed on donation ID.
+     */
+    public function getRemainingValidDonations(): array
+    {
+        return $this->remainingValidDonations;
     }
 }

--- a/src/Claimer.php
+++ b/src/Claimer.php
@@ -66,7 +66,6 @@ class Claimer
             return true;
         }
 
-        // Copy (unmodified) assoc array with a new name to clarify its use in the rest of the method.
         $this->remainingValidDonations = $donations;
 
         if (empty($claimOutcome['errors'])) {

--- a/src/Messenger/Handler/ClaimableDonationHandler.php
+++ b/src/Messenger/Handler/ClaimableDonationHandler.php
@@ -90,6 +90,11 @@ class ClaimableDonationHandler implements BatchHandlerInterface
 
             try {
                 $this->claimer->claim($donationsToRetry);
+
+                // Success – for the remainder!
+                foreach ($donationsToRetry as $donationId => $donation) {
+                    $acks[$donationId]->ack(true);
+                }
             } catch (ClaimException $retryException) {
                 $this->logger->error('Re-tried claim failed too. No more error detection.');
 

--- a/tests/ClaimerTest.php
+++ b/tests/ClaimerTest.php
@@ -36,7 +36,9 @@ class ClaimerTest extends TestCase
             new NullLogger(),
         );
 
-        $claimResult = $claimer->claim([$this->getTestDonation()]);
+        $claimResult = $claimer->claim([$this->getTestDonation()->id => $this->getTestDonation()]);
+
+        $this->assertCount(0, $claimer->getRemainingValidDonations());
         $this->assertTrue($claimResult);
     }
 
@@ -72,7 +74,15 @@ class ClaimerTest extends TestCase
             new NullLogger(),
         );
 
-        $claimer->claim([$this->getTestDonation()]);
+        $donation2 = clone $this->getTestDonation();
+        $donation2->id = 'efgh-5678';
+
+        $claimer->claim([
+            $this->getTestDonation()->id => $this->getTestDonation(),
+            'efgh-5678' => $donation2,
+        ]);
+
+        $this->assertCount(1, $claimer->getRemainingValidDonations());
     }
 
     public function testGeneralFatalError(): void
@@ -108,7 +118,7 @@ class ClaimerTest extends TestCase
             new NullLogger(),
         );
 
-        $claimer->claim([$this->getTestDonation()]);
+        $claimer->claim([$this->getTestDonation()->id => $this->getTestDonation()]);
     }
 
     public function testGeneralOtherErrors(): void
@@ -141,7 +151,7 @@ class ClaimerTest extends TestCase
             new NullLogger(),
         );
 
-        $claimer->claim([$this->getTestDonation()]);
+        $claimer->claim([$this->getTestDonation()->id => $this->getTestDonation()]);
     }
 
     public function testNoCorrelationIdOrErrors(): void
@@ -164,6 +174,6 @@ class ClaimerTest extends TestCase
             new NullLogger(),
         );
 
-        $claimer->claim([$this->getTestDonation()]);
+        $claimer->claim([$this->getTestDonation()->id => $this->getTestDonation()]);
     }
 }

--- a/tests/Messenger/Handler/ClaimableDonationHandlerTest.php
+++ b/tests/Messenger/Handler/ClaimableDonationHandlerTest.php
@@ -78,7 +78,12 @@ class ClaimableDonationHandlerTest extends TestCase
 
         $donation = $this->getTestDonation();
         $claimerProphecy = $this->prophesize(Claimer::class);
-        $claimerProphecy->claim(['abcd-1234' => $donation])->willThrow($dataException);
+        $claimerProphecy->claim(['abcd-1234' => $donation])
+            ->shouldBeCalledOnce()
+            ->willThrow($dataException);
+        $claimerProphecy->getRemainingValidDonations()
+            ->shouldBeCalledOnce()
+            ->willReturn([]);
 
         $acknowledgerProphecy = $this->prophesize(Acknowledger::class);
         // "Don't keep re-trying the claim – ack it to the original claim queue." But return value is false so this
@@ -119,6 +124,94 @@ class ClaimableDonationHandlerTest extends TestCase
         $this->assertEquals(0, $handler->__invoke($donation, $acknowledger));
     }
 
+    public function testDonationDataWithRetryFollowedByGeneralError(): void
+    {
+        $dataException = new DonationDataErrorsException(
+            [
+                'abcd-1234' => [
+                    'donation_id' => 'abcd-1234',
+                    'message' => "Invalid content found at element 'Sur'",
+                    'location' => '/hd:GovTalkMessage[1]/hd:Body[1]/r68:IRenvelope[1]/r68:R68[1]/' .
+                        'r68:Claim[1]/r68:Repayment[1]/r68:GAD[1]/r68:Donor[1]/r68:Sur[1]',
+                ],
+            ],
+            // Specific error string not used here and is tested specifically in DonationDataErrorsExceptionTest.
+            'Array [...]',
+        );
+
+        $donation1 = $this->getTestDonation();
+        $donation2 = clone $donation1;
+        $donation2->id = 'efgh-5678';
+        $claimerProphecy = $this->prophesize(Claimer::class);
+
+        // First claim for 2x donations gives a single donation error.
+        $claimerProphecy->claim(['abcd-1234' => $donation1, 'efgh-5678' => $donation2])
+            ->shouldBeCalledOnce()
+            ->willThrow($dataException);
+
+        $claimerProphecy->getRemainingValidDonations()
+            ->shouldBeCalledOnce()
+            ->willReturn(['efgh-5678' => $donation2]);
+
+        // Second claim for the remaining donation gives a general error.
+        $claimerProphecy->claim(['efgh-5678' => $donation2])
+            ->shouldBeCalledOnce()
+            ->willThrow(UnexpectedResponseException::class);
+
+        $acknowledger1Prophecy = $this->prophesize(Acknowledger::class);
+        // "Don't keep re-trying the claim – ack it to the original claim queue." But return value is false so this
+        // is distinguisable in the expected call from a 'processed' ack.
+        $acknowledger1Prophecy->ack(false)->shouldBeCalledOnce();
+        $acknowledger1 = $acknowledger1Prophecy->reveal();
+
+        $acknowledger2Prophecy = $this->prophesize(Acknowledger::class);
+        $acknowledger2Prophecy->nack(Argument::type(UnexpectedResponseException::class))
+            ->shouldBeCalledOnce();
+        $acknowledger2 = $acknowledger2Prophecy->reveal();
+
+        $failMessageStamps1 = [
+            new BusNameStamp('claimbot.donation.error'),
+            new TransportMessageIdStamp('claimbot.donation.error.abcd-1234'),
+        ];
+        $failMessageEnvelope = new Envelope($donation1, $failMessageStamps1);
+
+        $failMessageStamps2 = [
+            new BusNameStamp('claimbot.donation.error'),
+            new TransportMessageIdStamp('claimbot.donation.error.efgh-5678'),
+        ];
+        $failMessageEnvelope2 = new Envelope($donation2, $failMessageStamps2);
+
+        $outboundBusProphecy = $this->prophesize(OutboundMessageBus::class);
+        // https://github.com/phpspec/prophecy/issues/463#issuecomment-574123290
+        $outboundBusProphecy->dispatch($failMessageEnvelope)
+            ->shouldBeCalledOnce()
+            ->willReturn($failMessageEnvelope);
+        $outboundBusProphecy->dispatch($failMessageEnvelope2)
+            ->shouldBeCalledOnce()
+            ->willReturn($failMessageEnvelope2);
+
+        $settingsProphecy = $this->prophesize(SettingsInterface::class);
+        $settingsProphecy->get('current_batch_size')
+            ->shouldBeCalledOnce()
+            ->willReturn(2);
+
+        $container = $this->getContainer();
+        $container->set(Claimer::class, $claimerProphecy->reveal());
+        $container->set(OutboundMessageBus::class, $outboundBusProphecy->reveal());
+        $container->set(SettingsInterface::class, $settingsProphecy->reveal());
+
+        $handler = new ClaimableDonationHandler(
+            $container->get(Claimer::class),
+            $container->get(LoggerInterface::class),
+            $container->get(OutboundMessageBus::class),
+            $container->get(SettingsInterface::class),
+        );
+
+        // These return "The number of pending messages in the batch if $ack is not null".
+        $this->assertEquals(1, $handler->__invoke($donation1, $acknowledger1));
+        $this->assertEquals(0, $handler->__invoke($donation2, $acknowledger2));
+    }
+
     public function testDonationDataErrorAndFailureQueueDispatchError(): void
     {
         $dataException = new DonationDataErrorsException(
@@ -137,6 +230,9 @@ class ClaimableDonationHandlerTest extends TestCase
         $donation = $this->getTestDonation();
         $claimerProphecy = $this->prophesize(Claimer::class);
         $claimerProphecy->claim(['abcd-1234' => $donation])->willThrow($dataException);
+        $claimerProphecy->getRemainingValidDonations()
+            ->shouldBeCalledOnce()
+            ->willReturn([]);
 
         $acknowledgerProphecy = $this->prophesize(Acknowledger::class);
         // "Don't keep re-trying the claim – ack it to the original claim queue." But return value is false so this

--- a/tests/Messenger/Handler/ClaimableDonationHandlerTest.php
+++ b/tests/Messenger/Handler/ClaimableDonationHandlerTest.php
@@ -124,6 +124,85 @@ class ClaimableDonationHandlerTest extends TestCase
         $this->assertEquals(0, $handler->__invoke($donation, $acknowledger));
     }
 
+    public function testDonationDataWithRetrySuccess(): void
+    {
+        $dataException = new DonationDataErrorsException(
+            [
+                'abcd-1234' => [
+                    'donation_id' => 'abcd-1234',
+                    'message' => "Invalid content found at element 'Sur'",
+                    'location' => '/hd:GovTalkMessage[1]/hd:Body[1]/r68:IRenvelope[1]/r68:R68[1]/' .
+                        'r68:Claim[1]/r68:Repayment[1]/r68:GAD[1]/r68:Donor[1]/r68:Sur[1]',
+                ],
+            ],
+            // Specific error string not used here and is tested specifically in DonationDataErrorsExceptionTest.
+            'Array [...]',
+        );
+
+        $donation1 = $this->getTestDonation();
+        $donation2 = clone $donation1;
+        $donation2->id = 'efgh-5678';
+        $claimerProphecy = $this->prophesize(Claimer::class);
+
+        // First claim for 2x donations gives a single donation error.
+        $claimerProphecy->claim(['abcd-1234' => $donation1, 'efgh-5678' => $donation2])
+            ->shouldBeCalledOnce()
+            ->willThrow($dataException);
+
+        $claimerProphecy->getRemainingValidDonations()
+            ->shouldBeCalledOnce()
+            ->willReturn(['efgh-5678' => $donation2]);
+
+        // Second claim for the remaining donation gives a general error.
+        $claimerProphecy->claim(['efgh-5678' => $donation2])
+            ->shouldBeCalledOnce()
+            ->willReturn(true);
+
+        $acknowledger1Prophecy = $this->prophesize(Acknowledger::class);
+        // "Don't keep re-trying the claim – ack it to the original claim queue." But return value is false so this
+        // is distinguisable in the expected call from a 'processed' ack.
+        $acknowledger1Prophecy->ack(false)->shouldBeCalledOnce();
+        $acknowledger1 = $acknowledger1Prophecy->reveal();
+
+        $acknowledger2Prophecy = $this->prophesize(Acknowledger::class);
+        $acknowledger2Prophecy->ack(true)
+            ->shouldBeCalledOnce();
+        $acknowledger2 = $acknowledger2Prophecy->reveal();
+
+        $failMessageStamps1 = [
+            new BusNameStamp('claimbot.donation.error'),
+            new TransportMessageIdStamp('claimbot.donation.error.abcd-1234'),
+        ];
+        $failMessageEnvelope = new Envelope($donation1, $failMessageStamps1);
+
+        $outboundBusProphecy = $this->prophesize(OutboundMessageBus::class);
+        // https://github.com/phpspec/prophecy/issues/463#issuecomment-574123290
+        $outboundBusProphecy->dispatch($failMessageEnvelope)
+            ->shouldBeCalledOnce()
+            ->willReturn($failMessageEnvelope);
+
+        $settingsProphecy = $this->prophesize(SettingsInterface::class);
+        $settingsProphecy->get('current_batch_size')
+            ->shouldBeCalledOnce()
+            ->willReturn(2);
+
+        $container = $this->getContainer();
+        $container->set(Claimer::class, $claimerProphecy->reveal());
+        $container->set(OutboundMessageBus::class, $outboundBusProphecy->reveal());
+        $container->set(SettingsInterface::class, $settingsProphecy->reveal());
+
+        $handler = new ClaimableDonationHandler(
+            $container->get(Claimer::class),
+            $container->get(LoggerInterface::class),
+            $container->get(OutboundMessageBus::class),
+            $container->get(SettingsInterface::class),
+        );
+
+        // These return "The number of pending messages in the batch if $ack is not null".
+        $this->assertEquals(1, $handler->__invoke($donation1, $acknowledger1));
+        $this->assertEquals(0, $handler->__invoke($donation2, $acknowledger2));
+    }
+
     public function testDonationDataWithRetryFollowedByGeneralError(): void
     {
         $dataException = new DonationDataErrorsException(


### PR DESCRIPTION
Also fix superfluous `addClaimingOrganisation()` calls